### PR TITLE
symlinked mi-scheduler to the cli

### DIFF
--- a/mi-scheduler
+++ b/mi-scheduler
@@ -1,0 +1,1 @@
+srcopsmetrics/cli.py


### PR DESCRIPTION
symlinked mi-scheduler to the cli
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

cronjob requires the symlink files to execute cli
https://github.com/thoth-station/thoth-application/blob/2205bb55ab30f6857b2c4891e5b278a5b1b6ba39/mi-scheduler/base/cronjob.yaml#L25

