### PR TITLE
Rename current contentfile to ReadMe

### DIFF
--- a/srcopsmetrics/entities/__init__.py
+++ b/srcopsmetrics/entities/__init__.py
@@ -17,11 +17,5 @@
 
 """Entities imports."""
 
-from .interface import Entity
-from .content_file import ContentFile
-from .issue import Issue
-from .pull_request import PullRequest
-
 NOT_FOR_INSPECTION = {"interface", "template", "tools"}
 
-__all__ = ["Entity", "ContentFile", "Issue", "PullRequest"]

--- a/srcopsmetrics/entities/content_file.py
+++ b/srcopsmetrics/entities/content_file.py
@@ -29,8 +29,8 @@ from srcopsmetrics.entities import Entity
 _LOGGER = logging.getLogger(__name__)
 
 
-class ContentFile(Entity):
-    """GitHub ContentFile entity."""
+class ReadMe(Entity):
+    """GitHub ReadMe entity."""
 
     entity_schema = Schema({"name": str, "path": str, "content": str, "type": str, "license": str, "size": int,})
 
@@ -41,7 +41,6 @@ class ContentFile(Entity):
 
     def analyse(self) -> List[GithubContentFile]:
         """Override :func:`~Entity.analyse`."""
-        # TODO: Extend to all types of files. Currently only README are considered.
         # TODO: recursive Readme analysis - is that a good idea?
 
         if self.previous_knowledge is None or len(self.previous_knowledge) == 0:


### PR DESCRIPTION
## Description

The entity of `ContentFile` is rather a ReadMe entity than a general Content File on GitHub. Therefore it shold be more appropriate to name it as a `ReadMe` and leave other Content File types for entities that are going to be implemented in future.

## This introduces a breaking change

- [ ] Yes
- [X] No
