### PR TITLE
Add Commits as entities

### DIFF
--- a/srcopsmetrics/entities/commit.py
+++ b/srcopsmetrics/entities/commit.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2020 Dominik Tuchyna
+#
+# This file is part of thoth-station/mi - Meta-information Indicators.
+#
+# thoth-station/mi - Meta-information Indicators is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# thoth-station/mi - Meta-information Indicators is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with thoth-station/mi - Meta-information Indicators.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Commit entity."""
+
+from typing import Dict, List
+
+from github.Commit import Commit as GithubCommit
+from voluptuous.schema_builder import Schema
+from datetime import datetime
+
+from srcopsmetrics.entities import Entity
+
+
+class Commit(Entity):
+    """Commit entity class."""
+
+    entity_schema = Schema(
+        {
+            "pull_request": int,
+            "patch": Schema({str: str}),
+            "author": str,
+            "message": str,
+            "date": int,
+            "additions": int,
+            "deletions": int,
+        }
+    )
+
+    def analyse(self) -> List[GithubCommit]:
+        """Override :func:`~Entity.analyse`."""
+        return [c for c in self.get_raw_github_data() if c.sha not in self.previous_knowledge.keys()]
+
+    def store(self, commit: GithubCommit):
+        """Override :func:`~Entity.store`."""
+        pull_request_id = commit.get_pulls()[0].number if commit.get_pulls().totalCount != 0 else None
+
+        self.stored_entities[commit.sha] = {
+            "pull_request": pull_request_id,
+            "patch": Commit.get_patches_for_files(commit),
+            "author": commit.author.login,
+            "message": commit.commit.message,
+            "date": int(datetime.strptime(commit.last_modified, "%a, %d %b %Y %X %Z").timestamp()),
+            "additions": commit.stats.additions,
+            "deletions": commit.stats.deletions,
+        }
+
+    @staticmethod
+    def get_patches_for_files(commit: GithubCommit) -> Dict[str, str]:
+        """Inspect whole patch according to specific files."""
+        return {f.filename: f.patch for f in commit.files}
+
+    def get_raw_github_data(self) -> List[GithubCommit]:
+        """Override :func:`~Entity.get_raw_github_data`."""
+        return self.repository.get_commits()

--- a/srcopsmetrics/entities/commit.py
+++ b/srcopsmetrics/entities/commit.py
@@ -43,7 +43,7 @@ class Commit(Entity):
 
     def analyse(self) -> List[GithubCommit]:
         """Override :func:`~Entity.analyse`."""
-        return [c for c in self.get_raw_github_data() if c.sha not in self.previous_knowledge.keys()]
+        return [c for c in self.get_raw_github_data() if c.sha not in self.previous_knowledge]
 
     def store(self, commit: GithubCommit):
         """Override :func:`~Entity.store`."""

--- a/srcopsmetrics/entities/pull_request.py
+++ b/srcopsmetrics/entities/pull_request.py
@@ -66,8 +66,6 @@ class PullRequest(Entity):
     def store(self, pull_request: GithubPullRequest):
         """Override :func:`~Entity.store`."""
         commits = pull_request.commits
-        # TODO: Use commits to extract information.
-        # commits = [commit for commit in pull_request.get_commits()]
 
         created_at = int(pull_request.created_at.timestamp())
         closed_at = int(pull_request.closed_at.timestamp()) if pull_request.closed_at is not None else None


### PR DESCRIPTION
## Related Issues and Dependencies
Fixes #250 

## This introduces a breaking change

- [ ] Yes
- [X] No

## This Pull Request implements
Commits analyses for repository.
Alongside some stats, main feature analysed is commit's `patch`

## Description
two example commit entity snapshots from mi analysis:
First:
`  "3d63eb10f07db445b44d725bbdcf492648db5253": {
    "additions": 0,
    "author": "sesheta",
    "date": 1604387108,
    "deletions": 0,
    "message": ":pushpin: Automatic update of dependency thoth-storages from 0.25.15 to 0.25.16 (#274)\n\nCo-authored-by: Kebechet <noreply+kebechet@redhat.com>",
    "patch": {},
    "pull_request": 274
  }`

Second:
`
  "51dedfbb12efb77038086b1e2f9a984e142905ff": {
    "additions": 3,
    "author": "sesheta",
    "date": 1604386625,
    "deletions": 3,
    "message": ":pushpin: Automatic update of dependency thoth-storages from 0.25.15 to 0.25.16 (#272)\n\nCo-authored-by: Kebechet <noreply+kebechet@redhat.com>",
    "patch": {
      "Pipfile.lock": "@@ -864,11 +864,11 @@\n         },\n         \"thoth-storages\": {\n             \"hashes\": [\n-                \"sha256:affd10622661e41e35ac6ca1a5916966e8cdd33be518ced5690a64891092735e\",\n-                \"sha256:e9d27957e6816dbebf5a4760f7c7f1a5feb0aec416cf393b7b5381e5ad551cf3\"\n+                \"sha256:444d96838f9fe0694d4349a38de480073b83560ba79416872966faeed43d7ba4\",\n+                \"sha256:b2382aee19d9cdf863ec02e25d6567ffe0559ef9e515c497b63c1e0b64c9155d\"\n             ],\n             \"index\": \"pypi\",\n-            \"version\": \"==0.25.15\"\n+            \"version\": \"==0.25.16\"\n         },\n         \"toml\": {\n             \"hashes\": ["
    },
    "pull_request": 272
  },
  "6547b549cc8e8a2e3642b216a4e8d299567604eb": {
    "additions": 0,
    "author": "sesheta",
    "date": 1604387074,
    "deletions": 0,
    "message": ":pushpin: Automatic update of dependency thoth-storages from 0.25.15 to 0.25.16 (#273)\n\nCo-authored-by: Kebechet <noreply+kebechet@redhat.com>",
    "patch": {},
    "pull_request": 273
  }
`