### PR TITLE
Add specific labels to issues

### DIFF
--- a/srcopsmetrics/entities/issue.py
+++ b/srcopsmetrics/entities/issue.py
@@ -19,7 +19,7 @@
 """Issue entity class."""
 
 import logging
-from typing import Optional, Dict, Union
+from typing import Optional, Union
 
 from github.Issue import Issue as GithubIssue
 from github.PaginatedList import PaginatedList
@@ -59,30 +59,9 @@ class Issue(Entity):
             "created_at": int(issue.created_at.timestamp()),
             "closed_by": issue.closed_by.login if issue.closed_by is not None else None,
             "closed_at": int(issue.closed_at.timestamp()) if issue.closed_at is not None else None,
-            "labels": self.__class__.get_labels(issue),
+            "labels": GitHubKnowledge.get_labels(issue),
             "interactions": GitHubKnowledge.get_interactions(issue.get_comments()),
         }
-
-    @staticmethod
-    def get_labels(issue: GithubIssue) -> Dict[str, Dict[str, Union[int, str]]]:
-        """Get non standalone labels by filtering them from all of the labels."""
-        labels: Dict[str, Dict[str, Union[int, str]]] = {}
-
-        for event in issue.get_timeline():
-            if event.action != "labeled":
-                continue
-
-            label = issue.get_timeline()[0].__dict__.get("_rawData")["label"]
-            if label["name"] in labels.keys():
-                continue
-
-            labels[label["name"]] = {
-                "color": label["color"],
-                "labeled_at": int(event.created_at.timestamp()),
-                "labeler": event.actor.login,
-            }
-
-        return labels
 
     def previous_knowledge(self):
         """Override :func:`~Entity.previous_knowledge`."""

--- a/srcopsmetrics/entities/issue.py
+++ b/srcopsmetrics/entities/issue.py
@@ -19,11 +19,11 @@
 """Issue entity class."""
 
 import logging
-from typing import Optional, Union
 
 from github.Issue import Issue as GithubIssue
 from github.PaginatedList import PaginatedList
 from voluptuous.schema_builder import Schema
+from voluptuous.validators import Any
 
 from srcopsmetrics.entities import Entity
 from srcopsmetrics.entities.tools.knowledge import GitHubKnowledge
@@ -38,9 +38,9 @@ class Issue(Entity):
         {
             "created_by": str,
             "created_at": int,
-            "closed_by": Optional[str],
-            "closed_at": Optional[int],
-            "labels": {str: {str: Union[int, str]}},
+            "closed_by": Any(None, str),
+            "closed_at": Any(None, int),
+            "labels": {str: {str: Any(int, str)}},
             "interactions": {str: int},
         }
     )

--- a/srcopsmetrics/entities/issue.py
+++ b/srcopsmetrics/entities/issue.py
@@ -61,9 +61,30 @@ class Issue(Entity):
             "created_at": int(issue.created_at.timestamp()),
             "closed_by": issue.closed_by.login if issue.closed_by is not None else None,
             "closed_at": int(issue.closed_at.timestamp()) if issue.closed_at is not None else None,
-            "labels": GitHubKnowledge.get_non_standalone_labels(labels),
+            "labels": self.__class__.get_labels(issue),
             "interactions": GitHubKnowledge.get_interactions(issue.get_comments()),
         }
+
+    @staticmethod
+    def get_labels(issue: GithubIssue):
+        """Get non standalone labels by filtering them from all of the labels."""
+        labels = {}
+
+        for event in issue.get_timeline():
+            if event.action != "labeled":
+                continue
+
+            label = issue.get_timeline()[0].__dict__.get('_rawData')['label']
+            if label["name"] in labels.keys():
+                continue
+
+            labels[label["name"]] {
+                "color": label["color"],
+                "labeled_at": int(event.created_at.timestamp())
+                "labeler": event.actor.login,
+            }
+        
+        return labels
 
     def previous_knowledge(self):
         """Override :func:`~Entity.previous_knowledge`."""

--- a/srcopsmetrics/entities/pull_request.py
+++ b/srcopsmetrics/entities/pull_request.py
@@ -19,11 +19,12 @@
 """Pull Request entity class."""
 
 import logging
-from typing import Any, Dict, Generator, List, Optional
+from typing import Dict, Generator, List
 
 from github.PaginatedList import PaginatedList
 from github.PullRequest import PullRequest as GithubPullRequest
 from voluptuous.schema_builder import Schema
+from voluptuous.validators import Any
 
 from srcopsmetrics.entities import Entity
 from srcopsmetrics.entities.tools.knowledge import GitHubKnowledge
@@ -42,15 +43,15 @@ class PullRequest(Entity):
     entity_schema = Schema(
         {
             "size": str,
-            "labels": [str],
+            "labels": {str: {str: Any(int, str)}},
             "created_by": str,
             "created_at": int,
             # "approved_at": pr_approved,
             # "approved_by": pr_approved_by,
             # "time_to_approve": time_to_approve,
-            "closed_at": Optional[int],
-            "closed_by": Optional[str],
-            "merged_at": Optional[int],
+            "closed_at": Any(None, int),
+            "closed_by": Any(None, str),
+            "merged_at": Any(None, int),
             "commits_number": int,
             "referenced_issues": [int],
             "interactions": {str: int},

--- a/srcopsmetrics/entities/pull_request.py
+++ b/srcopsmetrics/entities/pull_request.py
@@ -86,7 +86,6 @@ class PullRequest(Entity):
 
         self.stored_entities[str(pull_request.number)] = {
             "size": pull_request_size,
-            "labels": GitHubKnowledge.get_non_standalone_labels(labels),
             "created_by": pull_request.user.login,
             "created_at": created_at,
             "closed_at": closed_at,
@@ -97,6 +96,7 @@ class PullRequest(Entity):
             "interactions": GitHubKnowledge.get_interactions(pull_request.get_issue_comments()),
             "reviews": self.extract_pull_request_reviews(pull_request),
             "requested_reviewers": self.extract_pull_request_review_requests(pull_request),
+            "labels": GitHubKnowledge.get_labels(pull_request.as_issue()),
         }
 
     def get_raw_github_data(self):

--- a/srcopsmetrics/entities/tools/knowledge.py
+++ b/srcopsmetrics/entities/tools/knowledge.py
@@ -19,10 +19,10 @@
 
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from github import Github, PaginatedList
-
+from github.Issue import Issue
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -133,3 +133,24 @@ class GitHubKnowledge:
             # we count by the num of words in comment
             interactions[comment.user.login] += len(comment.body.split(" "))
         return interactions
+
+    @staticmethod
+    def get_labels(issue: Issue) -> Dict[str, Dict[str, Union[int, str]]]:
+        """Get non standalone labels by filtering them from all of the labels."""
+        labels: Dict[str, Dict[str, Union[int, str]]] = {}
+
+        for event in issue.get_timeline():
+            if event.action != "labeled":
+                continue
+
+            label = issue.get_timeline()[0].__dict__.get("_rawData")["label"]
+            if label["name"] in labels.keys():
+                continue
+
+            labels[label["name"]] = {
+                "color": label["color"],
+                "labeled_at": int(event.created_at.timestamp()),
+                "labeler": event.actor.login,
+            }
+
+        return labels

--- a/srcopsmetrics/entities/tools/knowledge.py
+++ b/srcopsmetrics/entities/tools/knowledge.py
@@ -140,10 +140,11 @@ class GitHubKnowledge:
         labels: Dict[str, Dict[str, Union[int, str]]] = {}
 
         for event in issue.get_timeline():
-            if event.action != "labeled":
+
+            if event.event != "labeled":
                 continue
 
-            label = issue.get_timeline()[0].__dict__.get("_rawData")["label"]
+            label = event.__dict__.get("_rawData")["label"]
             if label["name"] in labels.keys():
                 continue
 


### PR DESCRIPTION
## Related Issues and Dependencies
Fixes #173 

## This introduces a breaking change

- [ ] Yes
- [X] No

## This Pull Request implements
More specific information for labels are extracted

## Description
`Label` entity was not created, but rather "added" to current Issue and Pull Request implementation.
Q: is this a good idea? or should we store Labels as a standalone entity?

Information extracted from label:
`labeler,
labeled_at,
color,`
