### PR TITLE
Add title and body attributes for Isse/PR inspection

### DIFF
--- a/srcopsmetrics/entities/issue.py
+++ b/srcopsmetrics/entities/issue.py
@@ -36,6 +36,8 @@ class Issue(Entity):
 
     entity_schema = Schema(
         {
+            "title": str,
+            "body": str,
             "created_by": str,
             "created_at": int,
             "closed_by": Any(None, str),
@@ -55,6 +57,8 @@ class Issue(Entity):
             return  # we analyze issues and prs differentely
 
         self.stored_entities[str(issue.number)] = {
+            "title": issue.title,
+            "body": issue.body,
             "created_by": issue.user.login,
             "created_at": int(issue.created_at.timestamp()),
             "closed_by": issue.closed_by.login if issue.closed_by is not None else None,

--- a/srcopsmetrics/entities/pull_request.py
+++ b/srcopsmetrics/entities/pull_request.py
@@ -42,13 +42,12 @@ class PullRequest(Entity):
 
     entity_schema = Schema(
         {
+            "title": str,
+            "body": str,
             "size": str,
             "labels": {str: {str: Any(int, str)}},
             "created_by": str,
             "created_at": int,
-            # "approved_at": pr_approved,
-            # "approved_by": pr_approved_by,
-            # "time_to_approve": time_to_approve,
             "closed_at": Any(None, int),
             "closed_by": Any(None, str),
             "merged_at": Any(None, int),
@@ -86,6 +85,8 @@ class PullRequest(Entity):
             pull_request_size = GitHubKnowledge.assign_pull_request_size(lines_changes=lines_changes)
 
         self.stored_entities[str(pull_request.number)] = {
+            "title": pull_request.title,
+            "body": pull_request.body,
             "size": pull_request_size,
             "created_by": pull_request.user.login,
             "created_at": created_at,


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [X] No

## Description

Added `title` and `body` knowledge extraction for `PullRequest` and `Issue` entities.

Example:
```
(SrcOpsMetrics) [xtuchyna@localhost SrcOpsMetrics]$ jq . srcopsmetrics/bot_knowledge/thoth-station/mi-scheduler/Issue.json {
  "59": {
    "title": "Consider standalone workflows for each of the Kebechet managers",
    "body": "**Is your feature request related to a problem? Please describe.**\r\nRelated to https://github.com/thoth-station/storages/pull/2134#discussion_r537430119\r\n",
    "created_by": "xtuchyna",
    "created_at": 1607336878,
    "closed_by": null,
    "closed_at": null,
    "labels": {
      "enhancement": {
        "color": "a2eeef",
        "labeled_at": 1607336878,
        "labeler": "xtuchyna"
      }
    },
    "interactions": {}
  },...
```

