### PR TITLE
Allow setting cli options by envvars

### DIFF
--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -104,7 +104,7 @@ def get_entities_as_list(entities_raw: Optional[str]) -> List[str]:
 )
 @click.option(
     "--thoth",
-    "-T",
+    "-t",
     is_flag=True,
     required=False,
     help=f"""Launch performance analysis of Thoth Kebechet managers for specified repository.""",
@@ -165,4 +165,4 @@ def cli(
 
 
 if __name__ == "__main__":
-    cli()
+    cli(auto_envvar_prefix="MI")


### PR DESCRIPTION
## Related Issues and Dependencies
Related to https://github.com/thoth-station/common/pull/1141#discussion_r600814175
cli options can be now setup with envvars in form of `MI_<cli_option>` where `<cli_option>` is the longer alias for cli option in `UPPER_CASE` with `snake_case` spacing

## This introduces a breaking change

- [ ] Yes
- [X] No

