### PR TITLE
Fix issue body, make it optional

### DIFF
--- a/srcopsmetrics/entities/issue.py
+++ b/srcopsmetrics/entities/issue.py
@@ -37,7 +37,7 @@ class Issue(Entity):
     entity_schema = Schema(
         {
             "title": str,
-            "body": str,
+            "body": Any(None, str),
             "created_by": str,
             "created_at": int,
             "closed_by": Any(None, str),


### PR DESCRIPTION
## Related Issues and Dependencies
Issue body does not have to contain any string

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request fixes
e.g. kebechet `Issue` data extraction failed due to this issue:
```
INFO:srcopsmetrics.iterator:Analysing Issue no. 247/250
INFO:srcopsmetrics.iterator:Analysing Issue no. 248/250
INFO:srcopsmetrics.iterator:Analysing Issue no. 249/250
INFO:srcopsmetrics.iterator:[ API requests remaining: 4261 ]
INFO:srcopsmetrics.iterator:Analysing Issue no. 250/250
INFO:srcopsmetrics.iterator:Cached knowledge could not be saved
Traceback (most recent call last):
  File "/home/xtuchyna/git/forks/SrcOpsMetrics/srcopsmetrics/cli.py", line 168, in <module>
    cli(auto_envvar_prefix="MI")
  File "/home/xtuchyna/.local/share/virtualenvs/SrcOpsMetrics-Vwmk3Tpf/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/xtuchyna/.local/share/virtualenvs/SrcOpsMetrics-Vwmk3Tpf/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/xtuchyna/.local/share/virtualenvs/SrcOpsMetrics-Vwmk3Tpf/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/xtuchyna/.local/share/virtualenvs/SrcOpsMetrics-Vwmk3Tpf/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/xtuchyna/git/forks/SrcOpsMetrics/srcopsmetrics/cli.py", line 138, in cli
    analyse_projects(projects=tupled_repos, is_local=is_local, entities=entities_args)
  File "/home/xtuchyna/git/forks/SrcOpsMetrics/srcopsmetrics/bot_knowledge.py", line 89, in analyse_projects
    github_knowledge.analyse_entity(
  File "/home/xtuchyna/git/forks/SrcOpsMetrics/srcopsmetrics/github_knowledge.py", line 188, in analyse_entity
    analysis.save_analysed_knowledge()
  File "/home/xtuchyna/git/forks/SrcOpsMetrics/srcopsmetrics/iterator.py", line 111, in save_analysed_knowledge
    self.entity.save_knowledge(is_local=self.is_local)
  File "/home/xtuchyna/git/forks/SrcOpsMetrics/srcopsmetrics/entities/interface.py", line 114, in save_knowledge
    self.entities_schema()(self.stored_entities)  # check for entities schema
  File "/home/xtuchyna/.local/share/virtualenvs/SrcOpsMetrics-Vwmk3Tpf/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/home/xtuchyna/.local/share/virtualenvs/SrcOpsMetrics-Vwmk3Tpf/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 594, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/home/xtuchyna/.local/share/virtualenvs/SrcOpsMetrics-Vwmk3Tpf/lib/python3.8/site-packages/voluptuous/schema_builder.py", line 432, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: expected str for dictionary value @ data['647']['body']
```
