### PR TITLE
Include empty repo check

### DIFF
--- a/srcopsmetrics/kebechet_metrics.py
+++ b/srcopsmetrics/kebechet_metrics.py
@@ -30,7 +30,8 @@ from github import Github
 
 from srcopsmetrics import utils
 from srcopsmetrics.entities.issue import Issue
-from srcopsmetrics.entities.pull_request import PullRequest
+from srcopsmetrics.entities.pull_request import (
+    PullRequest)
 from srcopsmetrics.storage import KnowledgeStorage
 
 BOT_NAMES = {"sesheta"}
@@ -149,12 +150,12 @@ class KebechetMetrics:
 
         return df.sort_values(by=["date"]).reset_index(drop=True)
 
-    def get_overall_stats_update_manager(self):
+    def get_overall_stats_update_manager(self) -> Dict[str, Any]:
         """Return stats over whole repository age."""
         prs = self._get_update_manager_pull_requests()
 
         if not prs:
-            return []
+            return {}
 
         stats: Dict[str, Any] = {}
         stats["created_pull_requests"] = len(prs)
@@ -172,7 +173,7 @@ class KebechetMetrics:
 
         return stats
 
-    def get_daily_stats_update_manager(self):
+    def get_daily_stats_update_manager(self) -> Dict[str, Any]:
         """Get daily stats.
 
         If self.today set to true, return only stats for current day.
@@ -180,7 +181,7 @@ class KebechetMetrics:
         prs = self._get_update_manager_pull_requests()
 
         if not prs:
-            return []
+            return {}
 
         prs["days"] = prs.apply(lambda x: datetime.fromtimestamp(x["date"]).date(), axis=1)
         today = datetime.now().date()

--- a/srcopsmetrics/kebechet_metrics.py
+++ b/srcopsmetrics/kebechet_metrics.py
@@ -141,6 +141,9 @@ class KebechetMetrics:
 
             data.append([created_at, pr_type, ttm, ttfr, tta, merged_by_kebechet_bot, rejected_by_kebechet_bot])
 
+        if not data:
+            return []
+
         df = pd.DataFrame(data)
         df.columns = ["date", "type", "ttm", "ttfr", "tta", "merged_by_kebechet_bot", "rejected_by_kebechet_bot"]
 
@@ -149,6 +152,9 @@ class KebechetMetrics:
     def get_overall_stats_update_manager(self):
         """Return stats over whole repository age."""
         prs = self._get_update_manager_pull_requests()
+
+        if not prs:
+            return []
 
         stats: Dict[str, Any] = {}
         stats["created_pull_requests"] = len(prs)
@@ -172,6 +178,10 @@ class KebechetMetrics:
         If self.today set to true, return only stats for current day.
         """
         prs = self._get_update_manager_pull_requests()
+
+        if not prs:
+            return []
+
         prs["days"] = prs.apply(lambda x: datetime.fromtimestamp(x["date"]).date(), axis=1)
         today = datetime.now().date()
 

--- a/srcopsmetrics/kebechet_metrics.py
+++ b/srcopsmetrics/kebechet_metrics.py
@@ -143,7 +143,7 @@ class KebechetMetrics:
             data.append([created_at, pr_type, ttm, ttfr, tta, merged_by_kebechet_bot, rejected_by_kebechet_bot])
 
         if not data:
-            return []
+            return pd.DataFrame()
 
         df = pd.DataFrame(data)
         df.columns = ["date", "type", "ttm", "ttfr", "tta", "merged_by_kebechet_bot", "rejected_by_kebechet_bot"]
@@ -154,7 +154,7 @@ class KebechetMetrics:
         """Return stats over whole repository age."""
         prs = self._get_update_manager_pull_requests()
 
-        if not prs:
+        if prs.empty:
             return {}
 
         stats: Dict[str, Any] = {}
@@ -180,7 +180,7 @@ class KebechetMetrics:
         """
         prs = self._get_update_manager_pull_requests()
 
-        if not prs:
+        if prs.empty:
             return {}
 
         prs["days"] = prs.apply(lambda x: datetime.fromtimestamp(x["date"]).date(), axis=1)

--- a/srcopsmetrics/kebechet_metrics.py
+++ b/srcopsmetrics/kebechet_metrics.py
@@ -30,8 +30,7 @@ from github import Github
 
 from srcopsmetrics import utils
 from srcopsmetrics.entities.issue import Issue
-from srcopsmetrics.entities.pull_request import (
-    PullRequest)
+from srcopsmetrics.entities.pull_request import PullRequest
 from srcopsmetrics.storage import KnowledgeStorage
 
 BOT_NAMES = {"sesheta"}
@@ -115,7 +114,7 @@ class KebechetMetrics:
 
         return df.sort_values(by=["date"]).reset_index(drop=True)
 
-    def _get_update_manager_pull_requests(self):
+    def _get_update_manager_pull_requests(self) -> pd.DataFrame:
         data = []
         for pr in self.prs.values():
             pr_type = KebechetMetrics._get_update_manager_request_type(pr)
@@ -186,7 +185,7 @@ class KebechetMetrics:
         prs["days"] = prs.apply(lambda x: datetime.fromtimestamp(x["date"]).date(), axis=1)
         today = datetime.now().date()
 
-        stats: Dict[datetime, Any] = {}
+        stats: Dict[str, Any] = {}
         day_range = [today] if self.today else prs["days"].unique()
         for date in day_range:
             prs_day = prs[prs["days"] == date]


### PR DESCRIPTION
## Related Issues and Dependencies
It happened that some of the repositories can be empty. This PR adds check for empty data, so that analysis does not fail.
## This introduces a breaking change

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
Instead of skipping metrics evaluation, I decided to store empty lists like
```
{"overall": [], "daily": []}
```
so that we know that even though repository should use kebechet, it does not? WDYT, comment please
