### PR TITLE
Use len() in case of entities not being PaginatedList

### DIFF
--- a/srcopsmetrics/iterator.py
+++ b/srcopsmetrics/iterator.py
@@ -24,10 +24,10 @@ from datetime import datetime, timezone
 
 from github import Github
 from github.GithubException import GithubException
+from github.PaginatedList import PaginatedList
+from tqdm import tqdm
 
 from srcopsmetrics.entities import Entity
-
-from tqdm import tqdm
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,7 +83,8 @@ class KnowledgeAnalysis:
 
         try:
             entities = self.entity.analyse()
-            for idx, entity in enumerate(tqdm(entities, total=entities.totalCount), 1):
+            length = entities.totalCount if isinstance(entities, PaginatedList) else len(entities)
+            for idx, entity in enumerate(tqdm(entities, total=length), 1):
                 self.knowledge_updated = True
 
                 remaining = self.github.get_rate_limit().core.remaining


### PR DESCRIPTION
## Related Issues and Dependencies
Related to #390 
and also to https://github.com/PyGithub/PyGithub/issues/1939

## This introduces a breaking change

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
Entities to analyse are generally iterables, not just `PaginatedList`, therefore the `len()` is used in case the entities are not `PaginatedList`.

