### PR TITLE
Feature/kebechet analysis specific day

### DIFF
--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -18,12 +18,13 @@
 """This is the CLI for SrcOpsMetrics to create, visualize, use bot knowledge."""
 
 import logging
-from tqdm.contrib.logging import logging_redirect_tqdm
 import os
+from datetime import date
 from pathlib import Path
 from typing import List, Optional
 
 import click
+from tqdm.contrib.logging import logging_redirect_tqdm
 
 from srcopsmetrics.bot_knowledge import analyse_projects
 from srcopsmetrics.enums import EntityTypeEnum, StoragePath
@@ -113,7 +114,7 @@ def get_entities_as_list(entities_raw: Optional[str]) -> List[str]:
     "-t",
     is_flag=True,
     required=False,
-    help=f"""Launch performance analysis of Thoth Kebechet managers for specified repository.""",
+    help=f"""Launch performance analysis of Thoth Kebechet managers for specified repository for yesterday.""",
 )
 @click.option(
     "--metrics", "-m", is_flag=True, required=False, help=f"""Launch Metrics Calculation for specified repository.""",
@@ -160,9 +161,13 @@ def cli(
     for project in repos:
         os.environ["PROJECT"] = project
 
+    today = date.today()
+    yesterday = today.replace(day=today.day - 1)
+
     if thoth:
         if repository and not merge:
-            kebechet_metrics = KebechetMetrics(repository=repos[0], today=True, is_local=is_local)
+            today = date.today()
+            kebechet_metrics = KebechetMetrics(repository=repos[0], day=yesterday, is_local=is_local)
             kebechet_metrics.evaluate_and_store_kebechet_metrics()
 
         if metrics:
@@ -182,7 +187,7 @@ def cli(
 
     if merge:
         if thoth:
-            KebechetMetrics.merge_kebechet_metrics_today(is_local=is_local)
+            KebechetMetrics.merge_kebechet_metrics_for_day(day=yesterday, is_local=is_local)
         else:
             raise NotImplementedError
 

--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -166,7 +166,6 @@ def cli(
 
     if thoth:
         if repository and not merge:
-            today = date.today()
             kebechet_metrics = KebechetMetrics(repository=repos[0], day=yesterday, is_local=is_local)
             kebechet_metrics.evaluate_and_store_kebechet_metrics()
 

--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -19,7 +19,7 @@
 
 import logging
 import os
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import List, Optional
 
@@ -162,7 +162,7 @@ def cli(
         os.environ["PROJECT"] = project
 
     today = date.today()
-    yesterday = today.replace(day=today.day - 1)
+    yesterday = today - timedelta(days=1)
 
     if thoth:
         if repository and not merge:

--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -186,7 +186,7 @@ def cli(
 
     if merge:
         if thoth:
-            KebechetMetrics.merge_kebechet_metrics_for_day(day=yesterday, is_local=is_local)
+            KebechetMetrics.merge_kebechet_metrics_per_day(day=yesterday, is_local=is_local)
         else:
             raise NotImplementedError
 

--- a/srcopsmetrics/kebechet_metrics.py
+++ b/srcopsmetrics/kebechet_metrics.py
@@ -214,7 +214,7 @@ class KebechetMetrics:
             KnowledgeStorage(is_local=self.is_local).save_data(file_path=path.joinpath(file_name), data=stats)
 
     @staticmethod
-    def merge_kebechet_metrics_for_day(day: date, is_local: bool = False):
+    def merge_kebechet_metrics_per_day(day: date, is_local: bool = False):
         """Merge all the collected metrics under given parent directory."""
         overall_today = {
             "created_pull_requests": 0,


### PR DESCRIPTION
## Related Issues and Dependencies
Related to https://github.com/thoth-station/thoth-application/pull/1500#issuecomment-851471652
and https://github.com/thoth-station/mi-scheduler/pull/131
and https://github.com/thoth-station/kebechet/issues/546

## This introduces a breaking change

- [ ] Yes
- [X] No

## This Pull Request implements
Instead of using today's date as default, user needs to specify now from which date the kebechet statistics will be collected.
This allows us an inspection of yesterday's data for kebechet stats, so that we can merge all the collected data for a SLI/SLO metrics on how the kebechet did the day before.