### PR TITLE
Return empty dictionary if none prs

### DIFF
--- a/srcopsmetrics/kebechet_metrics.py
+++ b/srcopsmetrics/kebechet_metrics.py
@@ -117,6 +117,9 @@ class KebechetMetrics:
 
     def _get_update_manager_pull_requests(self) -> pd.DataFrame:
 
+        if self.prs.empty:
+            return pd.DataFrame()
+
         self.prs["type"] = self.prs["title"].apply(lambda x: get_update_manager_request_type(x))
 
         requests = self.prs[~self.prs["type"].isnull()].copy()


### PR DESCRIPTION
## Related Issues and Dependencies
Fixes #415 

## This introduces a breaking change

- [ ] Yes
- [X] No

## Description
If none prs were stored for repo (because the repo did not contain any) return empty dictionary when calculating metrics for it
