### PR TITLE
Use merge path inside kebechet metrics

### DIFF
--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -126,6 +126,13 @@ def get_entities_as_list(entities_raw: Optional[str]) -> List[str]:
     required=False,
     help=f"""Merge all of the aggregated data under given KNOWLEDGE_PATH.""",
 )
+@click.option(
+    "--merge-path",
+    "-M",
+    required=False,
+    default=StoragePath.MERGE_PATH.value,
+    help=f"""Data/statistics are stored under this path.""",
+)
 def cli(
     repository: Optional[str],
     organization: Optional[str],
@@ -139,10 +146,12 @@ def cli(
     thoth: bool,
     metrics: bool,
     merge: bool,
+    merge_path: str,
 ):
     """Command Line Interface for SrcOpsMetrics."""
     os.environ["IS_LOCAL"] = "True" if is_local else "False"
     os.environ[StoragePath.LOCATION_VAR.value] = knowledge_path
+    os.environ[StoragePath.MERGE_LOCATION_ENVVAR_NAME.value] = merge_path
 
     repos = []
 

--- a/srcopsmetrics/enums.py
+++ b/srcopsmetrics/enums.py
@@ -47,8 +47,11 @@ class StoragePath(Enum):
 
     DEFAULT = "./srcopsmetrics/"
     LOCATION_VAR = "KNOWLEDGE_PATH"
+    MERGE_LOCATION_ENVVAR_NAME = "MERGE_PATH"
     KNOWLEDGE = "bot_knowledge"
+    MERGE = "metrics"
     PROCESSED = "processed"
 
     KNOWLEDGE_PATH = DEFAULT + KNOWLEDGE
+    MERGE_PATH = DEFAULT + MERGE
     PROCESSED_PATH = DEFAULT + PROCESSED

--- a/srcopsmetrics/kebechet_metrics.py
+++ b/srcopsmetrics/kebechet_metrics.py
@@ -32,6 +32,7 @@ from srcopsmetrics import utils
 from srcopsmetrics.entities.issue import Issue
 from srcopsmetrics.entities.pull_request import PullRequest
 from srcopsmetrics.entities.tools.storage import KnowledgeStorage
+from srcopsmetrics.storage import get_merge_path
 
 BOT_NAMES = {"sesheta"}
 
@@ -44,7 +45,6 @@ UPDATE_TYPES_AND_KEYWORDS = {
 
 _LOGGER = logging.getLogger(__name__)
 _GITHUB_ACCESS_TOKEN = os.getenv("GITHUB_ACCESS_TOKEN")
-_ROOT_DIR = "kebechet-update-manager"
 
 
 def get_update_manager_request_type(title: str) -> Optional[str]:
@@ -71,6 +71,7 @@ class KebechetMetrics:
         self.issues = Issue(gh_repo).load_previous_knowledge(is_local=is_local)
         self.day = day
         self.is_local = is_local
+        self.root_dir = get_merge_path()
 
     def _get_least_square_polynomial_fit(self, x_series: pd.Series, y_series: pd.Series, degree: int = 3):
         """Apply least square polynomial fit on time metrics data."""
@@ -206,7 +207,7 @@ class KebechetMetrics:
         for get_stats in [self.update_manager]:
             stats = get_stats()
 
-            path = Path(f"./{_ROOT_DIR}/{self.repo_name}/")
+            path = Path(f"./{self.root_dir}/{self.repo_name}/")
             utils.check_directory(path)
 
             file_name = f"kebechet_{get_stats.__name__}"
@@ -235,7 +236,7 @@ class KebechetMetrics:
 
             file_name = f"kebechet_{manager_name}_{str(day)}.json"
 
-            for path in Path(Path(f"./{_ROOT_DIR}/")).rglob(f"*{file_name}"):
+            for path in Path(Path(f"./{get_merge_path()}/")).rglob(f"*{file_name}"):
                 if path.name == f"overall_{file_name}":
                     continue
                 data = ks.load_data(file_path=path, as_json=True)
@@ -248,7 +249,7 @@ class KebechetMetrics:
             ttm_median = np.nanmedian(ttms)
             overall_today["median_ttm"] = ttm_median if not np.isnan(ttm_median) else None
 
-            path = Path(f"./{_ROOT_DIR}/overall_{file_name}")
+            path = Path(f"./{get_merge_path()}/overall_{file_name}")
             ks.save_data(path, overall_today)
 
     def update_manager(self):

--- a/srcopsmetrics/storage.py
+++ b/srcopsmetrics/storage.py
@@ -33,6 +33,16 @@ from srcopsmetrics.enums import StoragePath
 _LOGGER = logging.getLogger(__name__)
 
 
+def get_knowledge_path():
+    """Return knowledge path value."""
+    return os.getenv(StoragePath.LOCATION_VAR.value, StoragePath.KNOWLEDGE_PATH.value)
+
+
+def get_merge_path():
+    """Return merge path value."""
+    return os.getenv(StoragePath.MERGE_LOCATION_ENVVAR_NAME.value, StoragePath.MERGE_PATH.value)
+
+
 class ProcessedKnowledge:
     """Decorator for Processing() methods implemented as a descriptor.
 


### PR DESCRIPTION
## Related Issues and Dependencies
Related to #434 

## This introduces a breaking change

- [ ] Yes
- [X] No

## Description
Use merge path and knowledge path as two different variables. This allows for efficient use of data for both kebechet and normal mi aggregation.
