### PR TITLE
Feature/require only string slug entities

### DIFF
--- a/srcopsmetrics/entities/interface.py
+++ b/srcopsmetrics/entities/interface.py
@@ -22,7 +22,7 @@ import logging
 import os
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
-from typing import Collection
+from typing import Collection, Optional
 
 import pandas as pd
 from github.Repository import Repository
@@ -39,7 +39,7 @@ _LOGGER = logging.getLogger(__name__)
 class Entity(metaclass=ABCMeta):
     """This class defines interface every entity class should implement."""
 
-    def __init__(self, repository: Repository):
+    def __init__(self, repository: Optional[Repository] = None, repository_name: Optional[str] = None):
         """Initialize entity with github repository.
 
         Every entity should be initialized just with the repository name.
@@ -47,6 +47,14 @@ class Entity(metaclass=ABCMeta):
         self.stored_entities = self.entities_schema()({})
         self.previous_knowledge = self.entities_schema()({})
         self.repository = repository
+
+        if repository_name:
+            self.repository_name = repository_name
+        elif repository:
+            self.repository_name = repository.full_name
+        else:
+            _LOGGER.info("Repository object or slug is required")
+            return None
 
     @classmethod
     def name(cls) -> str:
@@ -97,7 +105,7 @@ class Entity(metaclass=ABCMeta):
         path = Path.cwd().joinpath(os.getenv(StoragePath.LOCATION_VAR.value, StoragePath.DEFAULT.value))
         path = path.joinpath(StoragePath.KNOWLEDGE.value)
 
-        project_path = path.joinpath("./" + self.repository.full_name)
+        project_path = path.joinpath("./" + self.repository_name)
         utils.check_directory(project_path)
 
         appendix = ".json"  # if as_csv else ".json" TODO implement as_csv bool
@@ -146,22 +154,14 @@ class Entity(metaclass=ABCMeta):
 
     def load_previous_knowledge(self, is_local: bool = False, as_csv: bool = False) -> pd.DataFrame:
         """Load previously collected repo knowledge. If a repo was not inspected before, create its directory."""
-        if self.file_path is None and self.repository is None:
-            raise ValueError("Either filepath or project name have to be specified.")
-
-        df = (
-            KnowledgeStorage().load_locally(self.file_path)
-            if is_local
-            else KnowledgeStorage().load_remotely(self.file_path)
-        )
+        df = KnowledgeStorage(is_local=is_local).load_data(self.file_path, as_json=True)
 
         if df.empty:
             _LOGGER.info("No previous knowledge of type %s found" % self.name())
             return pd.DataFrame()
 
         _LOGGER.info(
-            "Found previous %s knowledge for %s with %d records"
-            % (self.name(), self.repository.full_name, len(df.index))
+            "Found previous %s knowledge for %s with %d records" % (self.name(), self.repository_name, len(df.index))
         )
         return df
 

--- a/srcopsmetrics/entities/tools/storage.py
+++ b/srcopsmetrics/entities/tools/storage.py
@@ -104,7 +104,7 @@ class KnowledgeStorage:
                 json.dump(data, f)
             _LOGGER.info("Saved locally at %s" % file_path)
 
-    def load_data(self, file_path: Optional[Path] = None, as_json: bool = False) -> Dict[str, Any]:
+    def load_data(self, file_path: Optional[Path] = None, as_json: bool = False) -> pd.DataFrame:
         """Load previously collected repo knowledge. If a repo was not inspected before, create its directory.
 
         Arguments:
@@ -120,17 +120,13 @@ class KnowledgeStorage:
 
         """
         if file_path is None:
-            raise ValueError("Filepath has to be specified.")
+            raise ValueError("Filepath is required.")
 
         results = (
             self.load_locally(file_path, as_json=as_json)
             if self.is_local
             else self.load_remotely(file_path, as_json=as_json)
         )
-
-        if results is None:
-            _LOGGER.info("File does not exist.")
-            return {}
 
         _LOGGER.info("Data from file %s loaded")
         return results

--- a/srcopsmetrics/entities/traffic.py
+++ b/srcopsmetrics/entities/traffic.py
@@ -17,8 +17,13 @@
 
 """Traffic stats class."""
 
+from datetime import datetime
 from typing import List
 
+from github.Clones import Clones
+from github.Path import Path
+from github.Referrer import Referrer
+from github.View import View
 from voluptuous.schema_builder import Schema
 from voluptuous.validators import Any
 
@@ -26,26 +31,65 @@ from srcopsmetrics.entities import Entity
 
 
 class Traffic(Entity):
-    """Template entity.
-
-    Serves as a skelet for implementing a new entity so the contributor
-    does not have to spend time copying everything from interface class.
-
-    For further inspiration look at other implemented entities like Issue
-    or PullRequest.
-    """
+    """Traffic entity."""
 
     entity_schema = Schema({int: {str: Any(str, int)}})
 
     def analyse(self) -> List[Any]:
         """Override :func:`~Entity.analyse`."""
+        return self.get_raw_github_data()
 
     def store(self, github_entity):
         """Override :func:`~Entity.store`."""
-        self.stored_entities["key"] = {
-            "extracted_information": github_entity.attribute,
-        }
+        id = None
+        type = None
+        today = datetime.today().date()
+
+        if isinstance(github_entity, View):
+            id = github_entity.timestamp
+
+            # today statistics of view and clones are never complete, have to wait for tomorrow
+            if id == today:
+                return
+
+            type = "view"
+        elif isinstance(github_entity, Clones):
+            id = github_entity.timestamp
+
+            if id == today:
+                return
+
+            type = "clones"
+        elif isinstance(github_entity, Referrer):
+            id = today
+            type = "referrer"
+        elif isinstance(github_entity, Path):
+            id = today
+            type = "path"
+
+        date_id = str(id)
+
+        if date_id not in self.previous_knowledge:
+            self.previous_knowledge[date_id] = {}
+        elif type in self.previous_knowledge[date_id]:
+            return
+
+        if date_id not in self.stored_entities:
+            self.stored_entities[date_id] = {}
+
+        data = github_entity.raw_data
+        data["type"] = type
+
+        if "timestamp" in data:
+            data.__delitem__("timestamp")
+
+        self.stored_entities[date_id] = data
 
     def get_raw_github_data(self):
         """Override :func:`~Entity.get_raw_github_data`."""
-        return self.repository.get_entity()
+        traffic_stats = self.repository.get_top_paths()
+        traffic_stats.extend(self.repository.get_top_referrers())
+        traffic_stats.extend(self.repository.get_views_traffic()["views"])
+        traffic_stats.extend(self.repository.get_clones_traffic()["clones"])
+
+        return traffic_stats

--- a/srcopsmetrics/entities/traffic.py
+++ b/srcopsmetrics/entities/traffic.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2021 Dominik Tuchyna
+#
+# This file is part of thoth-station/mi - Meta-information Indicators.
+#
+# thoth-station/mi - Meta-information Indicators is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# thoth-station/mi - Meta-information Indicators is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with thoth-station/mi - Meta-information Indicators.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Traffic stats class."""
+
+from typing import List
+
+from voluptuous.schema_builder import Schema
+from voluptuous.validators import Any
+
+from srcopsmetrics.entities import Entity
+
+
+class Traffic(Entity):
+    """Template entity.
+
+    Serves as a skelet for implementing a new entity so the contributor
+    does not have to spend time copying everything from interface class.
+
+    For further inspiration look at other implemented entities like Issue
+    or PullRequest.
+    """
+
+    entity_schema = Schema({int: {str: Any(str, int)}})
+
+    def analyse(self) -> List[Any]:
+        """Override :func:`~Entity.analyse`."""
+
+    def store(self, github_entity):
+        """Override :func:`~Entity.store`."""
+        self.stored_entities["key"] = {
+            "extracted_information": github_entity.attribute,
+        }
+
+    def get_raw_github_data(self):
+        """Override :func:`~Entity.get_raw_github_data`."""
+        return self.repository.get_entity()


### PR DESCRIPTION
## Related Issues and Dependencies
Related to #311

## This introduces a breaking change

- [ ] Yes
- [X] No

## Description
Github object is not necessary for entity object initialization. For data loading, string should be sufficient.
