### PR TITLE
Remove repo name tupling

### DIFF
--- a/srcopsmetrics/bot_knowledge.py
+++ b/srcopsmetrics/bot_knowledge.py
@@ -22,7 +22,7 @@ import os
 from importlib import import_module
 from pathlib import Path
 from pkgutil import iter_modules
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from srcopsmetrics.entities import Entity, NOT_FOR_INSPECTION
 from srcopsmetrics.exceptions import NotKnownEntitiesError
@@ -55,9 +55,7 @@ def _get_all_entities():
     return entities_classes
 
 
-def analyse_projects(
-    projects: List[Tuple[str, str]], is_local: bool = False, entities: Optional[List[str]] = None
-) -> None:
+def analyse_projects(projects: List[str], is_local: bool = False, entities: Optional[List[str]] = None) -> None:
     """Run Issues (that are not PRs), PRs, PR Reviews analysis on specified projects.
 
     Arguments:

--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -175,8 +175,7 @@ def cli(
     entities_args = get_entities_as_list(entities)
 
     if create_knowledge:
-        tupled_repos = [(lambda x: (x[0], x[1]))(repo.split("/")) for repo in repos]
-        analyse_projects(projects=tupled_repos, is_local=is_local, entities=entities_args)
+        analyse_projects(projects=repos, is_local=is_local, entities=entities_args)
 
     for project in repos:
         os.environ["PROJECT"] = project

--- a/srcopsmetrics/github_knowledge.py
+++ b/srcopsmetrics/github_knowledge.py
@@ -20,7 +20,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Type
 
 from github import ContentFile, Github, PaginatedList
 from github.Repository import Repository
@@ -42,15 +42,14 @@ class GitHubKnowledge:
     _FILENAME_ENTITY = {"Issue": "issues", "PullRequest": "pull_requests", "ContentFile": "content_file"}
 
     @github_handler
-    def connect_to_source(self, project: Tuple[str, str]) -> Repository:
+    def connect_to_source(self, project: str) -> Repository:
         """Connect to GitHub.
 
         :param project: Tuple source repo and repo name.
         """
         # Connect using PyGitHub
         g = Github(login_or_token=_GITHUB_ACCESS_TOKEN, timeout=GITHUB_TIMEOUT_SECONDS)
-        repo_name = project[0] + "/" + project[1]
-        repo = g.get_repo(repo_name)
+        repo = g.get_repo(project)
 
         return repo
 


### PR DESCRIPTION
## Related Issues and Dependencies
None

## This introduces a breaking change

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Removal of repo name tupling (dividing user-provided repository name into tuple `(org_name,repo_name)`, because it was not used.