### PR TITLE
Reduce approvers to pacospace and xtuchyna, add reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - fridex
   - pacospace
-  - sesheta
-  - goern
   - xtuchyna
 reviewers:
-  - kpostoffice
+  - pacospace
   - harshad16
+  - fridex
+  - kpostoffice
+  - goern
+  
+

--- a/OWNERS
+++ b/OWNERS
@@ -9,5 +9,5 @@ reviewers:
   - fridex
   - kpostoffice
   - goern
-  
+  - mayaCostantini
 

--- a/OWNERS
+++ b/OWNERS
@@ -10,4 +10,3 @@ reviewers:
   - kpostoffice
   - goern
   - mayaCostantini
-


### PR DESCRIPTION
## Description
So far, @pacospace  and myself are most familiar with project `mi`, therefore it makes sense to leave us as approvers, and make others reviewers for increasing code quality.

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- No

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->

