### PR TITLE
Add basic implementation for advise and version managers

### DIFF
--- a/srcopsmetrics/entities/interface.py
+++ b/srcopsmetrics/entities/interface.py
@@ -160,7 +160,12 @@ class Entity(metaclass=ABCMeta):
         if not is_local:
             ceph_filename = os.path.relpath(file_path).replace("./", "")
             s3 = KnowledgeStorage().get_ceph_store()
-            s3.store_document(to_save, ceph_filename)
+
+            if as_csv:
+                s3.store_blob(to_save, ceph_filename)
+            else:
+                s3.store_document(to_save, ceph_filename)
+
             _LOGGER.info("Saved on CEPH at %s/%s%s" % (s3.bucket, s3.prefix, ceph_filename))
         else:
             with open(file_path, "w") as f:

--- a/srcopsmetrics/entities/thoth_metrics.py
+++ b/srcopsmetrics/entities/thoth_metrics.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2022 Dominik Tuchyna
+#
+# This file is part of thoth-station/mi - Meta-information Indicators.
+#
+# thoth-station/mi - Meta-information Indicators is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# thoth-station/mi - Meta-information Indicators is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with thoth-station/mi - Meta-information Indicators.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Thoth metrics."""
+
+from typing import List
+
+from voluptuous.schema_builder import Schema
+from voluptuous.validators import Any
+
+from srcopsmetrics.entities import Entity
+
+
+class ThothMetrics(Entity):
+    """Thoth manager metrics template class for a repository.
+
+    Intended to be used only within polymorphism for loading and storing operations.
+    """
+
+    entity_schema = Schema({int: {str: Any(str, int)}})
+
+    def analyse(self) -> List[Any]:
+        """Override :func:`~Entity.analyse`."""
+        raise NotImplementedError("cannot use with metrics")
+
+    def store(self, github_entity):
+        """Override :func:`~Entity.store`."""
+        raise NotImplementedError("cannot use with metrics")
+
+    def get_raw_github_data(self):
+        """Override :func:`~Entity.get_raw_github_data`."""
+        raise NotImplementedError("cannot use with metrics")

--- a/srcopsmetrics/entities/thoth_version_manager_metrics.py
+++ b/srcopsmetrics/entities/thoth_version_manager_metrics.py
@@ -15,12 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with thoth-station/mi - Meta-information Indicators.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Advise manager metrics."""
+"""Thoth Version Manager Metrics class."""
 
 from srcopsmetrics.entities.thoth_metrics import ThothMetrics
 
 
-class ThothAdviseMetrics(ThothMetrics):
-    """Advise manager metrics class."""
+class ThothVersionManagerMetrics(ThothMetrics):
+    """Version manager metrics class."""
 
     pass


### PR DESCRIPTION
## Related Issues and Dependencies
Related to #560 

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- Yes

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->

## This Pull Request implements
Implement basic daily repostiory metrics for advise and version managers

## Description
Data is saved on Ceph (according to the namespace and endpoint where `mi` runs) in two files, that are updated daily (by scheduled daily workflows):
- `kebechet_advise_manager.csv`
```
$ cat kebechet_advise_manager.csv | head
,created_pull_requests,approved_pull_requests,merged_pull_requests,merged_by_bot,merged_by_other,rejected_pull_requests,rejected_by_bot,rejected_by_other,daily_mean_time_to_merge
2020-06-17,2,1,2,1,1,0,0,0,3509.0
2020-07-07,16,5,10,5,5,6,0,6,135.0
2020-07-08,2,1,2,1,1,0,0,0,3917.0
2020-07-14,4,2,4,2,2,0,0,0,84.0
2020-07-16,8,4,8,4,4,0,0,0,3390.0
2020-07-17,12,6,12,6,6,0,0,0,4137.0
2020-07-20,2,0,0,0,0,2,0,2,
2020-07-23,4,2,4,2,2,0,0,0,2912.0
2020-07-29,6,3,6,3,3,0,0,0,83.0
```


- `kebechet_version_manager.csv`
```
$ cat kebechet_version_manager.csv | head
,issues_created,issues_completed,issues_rejected
2022-04-05,1,1,0
2022-03-16,1,1,0
2021-12-01,1,1,0
2021-11-30,1,1,0
2021-09-03,1,1,0
2021-07-14,1,1,0
2021-07-09,1,1,0
2021-07-08,1,1,0
2021-07-07,2,2,0
```